### PR TITLE
Enable passing external configure options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,10 @@ BUILD_DIR := $(shell pwd)
 
 ifeq ($(GASNET_DEBUG),1)
 GASNET_INSTALL_DIR ?= $(shell pwd)/debug
-EXTRA_CONFIGURE_ARGS = --enable-debug
+GASNET_EXTRA_CONFIGURE_ARGS += --enable-debug
 else
 GASNET_INSTALL_DIR ?= $(shell pwd)/release
-EXTRA_CONFIGURE_ARGS =
+GASNET_EXTRA_CONFIGURE_ARGS +=
 endif
 
 GASNET_CONFIG ?= configs/config.$(CONDUIT).release
@@ -56,14 +56,14 @@ ifdef CROSS_CONFIGURE
 	chmod a+x $(GASNET_INSTALL_DIR)/CC.custom
 	# use our custom cc/CC wrappers and also force -fPIC
 	/bin/sed "s/'\(cc\)'/'\1.custom -fPIC'/I" < $(GASNET_VERSION)/other/contrib/$(CROSS_CONFIGURE) > $(GASNET_VERSION)/cross-configure
-	cd release; PATH=`pwd`:$$PATH /bin/sh $(BUILD_DIR)/$(GASNET_VERSION)/cross-configure --prefix=$(GASNET_INSTALL_DIR) `cat $(realpath $(GASNET_CONFIG))` $(EXTRA_CONFIGURE_ARGS)
+	cd release; PATH=`pwd`:$$PATH /bin/sh $(BUILD_DIR)/$(GASNET_VERSION)/cross-configure --prefix=$(GASNET_INSTALL_DIR) `cat $(realpath $(GASNET_CONFIG))` $(GASNET_EXTRA_CONFIGURE_ARGS)
 else
 # normal configure path
 	mkdir -p $(GASNET_INSTALL_DIR)
 ifeq ($(OVERRIDE_CC_AND_CXX),1)
-	cd $(GASNET_INSTALL_DIR); CC='mpicc -fPIC' CXX='mpicxx -fPIC' $(BUILD_DIR)/$(GASNET_VERSION)/configure --prefix=$(GASNET_INSTALL_DIR) --with-mpi-cflags=-fPIC `cat $(realpath $(GASNET_CONFIG))` $(EXTRA_CONFIGURE_ARGS)
+	cd $(GASNET_INSTALL_DIR); CC='mpicc -fPIC' CXX='mpicxx -fPIC' $(BUILD_DIR)/$(GASNET_VERSION)/configure --prefix=$(GASNET_INSTALL_DIR) --with-mpi-cflags=-fPIC `cat $(realpath $(GASNET_CONFIG))` $(GASNET_EXTRA_CONFIGURE_ARGS)
 else
-	cd $(GASNET_INSTALL_DIR); $(BUILD_DIR)/$(GASNET_VERSION)/configure --prefix=$(GASNET_INSTALL_DIR) --with-cflags=-fPIC --with-mpi-cflags=-fPIC `cat $(realpath $(GASNET_CONFIG))` $(EXTRA_CONFIGURE_ARGS)
+	cd $(GASNET_INSTALL_DIR); $(BUILD_DIR)/$(GASNET_VERSION)/configure --prefix=$(GASNET_INSTALL_DIR) --with-cflags=-fPIC --with-mpi-cflags=-fPIC `cat $(realpath $(GASNET_CONFIG))` $(GASNET_EXTRA_CONFIGURE_ARGS)
 endif
 endif
 


### PR DESCRIPTION
I encountered a system that requires `--enable-ibv-multirail --with-ibv-max-hcas=4` in Gasnet options. Now, options can be passed in through `GASNET_EXTRA_CONFIGURE_ARGS`.